### PR TITLE
Remove current implementation of SponsorLink for now

### DIFF
--- a/src/WebSocketeer/WebSocketeer.csproj
+++ b/src/WebSocketeer/WebSocketeer.csproj
@@ -14,11 +14,11 @@
     <PackageReference Include="Google.Protobuf" Version="3.22.1" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.52.0" Pack="false" />
     <PackageReference Include="RxFree" Version="1.1.2" PrivateAssets="all" />
-    <PackageReference Include="WebSocketChannel" Version="1.0.1" />
+    <PackageReference Include="WebSocketChannel" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CodeAnalysis\CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="None" />
+    <!--<ProjectReference Include="..\CodeAnalysis\CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="None" />-->
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Now that SponsorLink is OSS and based on received feedback it will change in many ways moving forward, we'll for now remove the current implementation from the package to address the issues that were raised.

See https://github.com/devlooped/SponsorLink